### PR TITLE
enabled advanced google closure optimizations

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,7 +7,9 @@
                       :asset-path "/js"
                       :build-options
                       {:cache-level :jars}
-                      :compiler-options {:optimizations :simple}
+                      :compiler-options {:optimizations :advanced
+                                         :pseudo-names true
+                                         :pretty-print  true}
                       :modules    {:app {:entries [fauxcel.core]}}
                       :devtools   {:after-load fauxcel.core/mount-root}}}
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,9 +7,10 @@
                       :asset-path "/js"
                       :build-options
                       {:cache-level :jars}
-                      :compiler-options {:optimizations :advanced
-                                         :pseudo-names true
-                                         :pretty-print  true}
+                      :compiler-options {:optimizations :advanced 
+                                         :pretty-print  false
+                                         :source-map false
+                                         :pseudo-names false}
                       :modules    {:app {:entries [fauxcel.core]}}
                       :devtools   {:after-load fauxcel.core/mount-root}}}
 

--- a/src/fauxcel/base/utility.cljs
+++ b/src/fauxcel/base/utility.cljs
@@ -24,14 +24,14 @@
 (defn el-by-cell-ref [cell-ref]
   (querySelector (str "#" cell-ref)))
 
-(defn changed! [cell-el]
-  (set! (-> cell-el .-dataset .-changed) true))
+(defn changed! [^js/HTMLElement cell-el]
+  (set! (.-changed (.-dataset cell-el)) true))
 
-(defn not-changed! [cell-el]
-  (set! (-> cell-el .-dataset .-changed) false))
+(defn not-changed! [^js/HTMLElement cell-el]
+  (set! (.-changed (.-dataset cell-el)) false))
 
-(defn changed? [cell-el]
-  (-> cell-el .-dataset .-changed))
+(defn changed? [^js/HTMLElement cell-el]
+  (.-changed (.-dataset cell-el)))
 
 
 
@@ -65,7 +65,7 @@
 (defn selection-cell-ref []
   (querySelector (str cells-parent-selector " input.selected")))
 
-(defn row-col-for-el [el]
+(defn row-col-for-el [^js/HTMLElement el]
   {:row (js/parseInt (-> el .-dataset .-row))
    :col (js/parseInt (-> el .-dataset .-col))})
 
@@ -77,7 +77,7 @@
   (for [col (range 1 max-cols)]
     [:span.col-label {:key (str "col-label-" (char (+ col 64)))} (char (+ col 64))]))
 
-(defn cell-ref-for-input [input-el]
+(defn cell-ref-for-input [^js/HTMLElement input-el]
   (cell-ref (js/parseInt (-> input-el .-dataset .-row)) (js/parseInt (-> input-el .-dataset .-col))))
 
 (defn cell-data-for
@@ -162,7 +162,7 @@
                  ;(.focus curr-cell)
          )))})
 
-(defn handle-cell-blur [cell-el parser]
+(defn handle-cell-blur [^js/HTMLElement cell-el parser]
     (when (changed? cell-el)
       (set! (-> cell-el .-readOnly) true) ; set back to readonly
       (let [val (-> cell-el .-value)

--- a/src/fauxcel/base/utility.cljs
+++ b/src/fauxcel/base/utility.cljs
@@ -3,7 +3,7 @@
    [reagent.core :as r]
    [reagent.ratom]
    [fauxcel.base.state :as state :refer [cells-map current-selection current-formula]]
-   [fauxcel.util.dom :as dom :refer [$]]))
+   [fauxcel.util.dom :as dom :refer [querySelector]]))
 
 ;; ---------------------------------------------
 ;; copied from my ClojureScript7 project
@@ -22,7 +22,7 @@
    (str (char (+ col 64)) row)))
 
 (defn el-by-cell-ref [cell-ref]
-  ($ (str "#" cell-ref)))
+  (querySelector (str "#" cell-ref)))
 
 (defn changed! [cell-el]
   (set! (-> cell-el .-dataset .-changed) true))
@@ -45,7 +45,7 @@
   ([cell-ref] (scroll-to-cell cell-ref false true)) ; default just scroll, no range check, smooth yes
   ([cell-ref check-if-out-of-range?] (scroll-to-cell cell-ref check-if-out-of-range? true))
   ([cell-ref check-if-out-of-range? smooth-scroll?]
-   (let [parent-el ($ cells-parent-selector)
+   (let [parent-el (querySelector cells-parent-selector)
          child-el (el-by-cell-ref cell-ref)
          child-offset-l (-> child-el .-offsetLeft)
          child-offset-t (-> child-el .-offsetTop)
@@ -63,7 +63,7 @@
        (.scrollTo parent-el (clj->js scroll-to-info))))))
 
 (defn selection-cell-ref []
-  ($ (str cells-parent-selector " input.selected")))
+  (querySelector (str cells-parent-selector " input.selected")))
 
 (defn row-col-for-el [el]
   {:row (js/parseInt (-> el .-dataset .-row))
@@ -115,7 +115,7 @@
 (defn update-selection!
   ([el] (update-selection! el false))
   ([el get-formula?]
-   (when (not= @current-selection "") (dom/remove-class ($ (str "#" @current-selection)) "selected"))
+   (when (not= @current-selection "") (dom/remove-class (querySelector (str "#" @current-selection)) "selected"))
    (dom/add-class-name el "selected")
    (reset! current-selection (cell-ref-for-input el))
    (.focus el)
@@ -138,22 +138,22 @@
                                 rc-new {:row (dec (:row rc)) :col (:col rc)}]
                             (when (> (:row rc) 1)
                               (scroll-to-cell (cell-ref rc-new) true)
-                              (update-selection! ($ (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
+                              (update-selection! (querySelector (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
          "ArrowDown" (doall (let [rc (row-col-for-el curr-cell)
                                   rc-new {:row (inc (:row rc)) :col (:col rc)}]
                               (when (< (:row rc) (dec max-rows))
                                 (scroll-to-cell (cell-ref rc-new) true)
-                                (update-selection! ($ (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
+                                (update-selection! (querySelector (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
          "ArrowLeft" (doall (let [rc (row-col-for-el curr-cell)
                                   rc-new {:row (:row rc) :col (dec (:col rc))}]
                               (when (> (:col rc) 1)
                                 (scroll-to-cell (cell-ref rc-new) true)
-                                (update-selection! ($ (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
+                                (update-selection! (querySelector (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
          "ArrowRight" (doall (let [rc (row-col-for-el curr-cell)
                                    rc-new {:row (:row rc) :col (inc (:col rc))}]
                                (when (< (:col rc) (dec max-cols))
                                  (scroll-to-cell (cell-ref rc-new) true)
-                                 (update-selection! ($ (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
+                                 (update-selection! (querySelector (str "#" (cell-ref (:row rc-new) (:col rc-new))))))))
          "Enter" (doall (set! (.-readOnly curr-cell) false)
                         (.focus curr-cell))
          "Escape" (js/console.log "escape")

--- a/src/fauxcel/util/dom.cljs
+++ b/src/fauxcel/util/dom.cljs
@@ -34,16 +34,15 @@
     (if-not (contains-class? el class-name)
       (.setAttribute el "class" (str cur-class-name " " class-name)))))
 
-
 (defn swap-class [el from-class to-class]
-  ;([el from-class] (swap-class el from-class " "))
-  (let [cur-class-name (.getAttribute el "class")
-        classes (s/split cur-class-name #"(?i)[\s]+")] ; split class name property into vector of classes
-    (when (c/vector-contains? classes from-class)
-      (.setAttribute el "class"
-             ; remove the class to be swapped then add the new class
-             ; join classes vector with spaces again and set the className property on the element
-            (s/join " " (concat (c/remove-val-from-vector classes from-class) [to-class]))))))
+  (when el
+    (let [cur-class-name (.getAttribute el "class")
+          classes (s/split cur-class-name #"(?i)[\s]+")] ; split class name property into vector of classes
+      (when (c/vector-contains? classes from-class)
+        (.setAttribute el "class"
+               ; remove the class to be swapped then add the new class
+               ; join classes vector with spaces again and set the className property on the element
+              (s/join " " (concat (c/remove-val-from-vector classes from-class) [to-class])))))))
 
 (defn remove-class [el class]
   (swap-class el class " "))

--- a/src/fauxcel/util/dom.cljs
+++ b/src/fauxcel/util/dom.cljs
@@ -10,10 +10,10 @@
 ;;    because I was still figuring out how to use reagent at the time
 ;; ---------------------------------------------
 
-(defn $ [selector]
+(defn querySelector [selector]
   (js/document.querySelector selector))
 
-(defn $$ [selector]
+(defn querySelectorAll [selector]
   (array-seq (js/document.querySelectorAll selector)))
 
 (defn el-by-id [el-id]
@@ -88,7 +88,7 @@
   (post-animation-fn))
 
 (defn canvas-init [canvas ctx]
-  (reset! canvas ($ "#circles-canvas"))
+  (reset! canvas (querySelector "#circles-canvas"))
   (set! (.-width @canvas) (.-offsetWidth @canvas))
   (set! (.-height @canvas) (.-offsetHeight @canvas))
   (reset! ctx (.getContext @canvas "2d")))


### PR DESCRIPTION
Some js-interop DOM functions were producing warnings that then broke the app when advanced optimizations were enabled in the Closure compiler. Added type hints to fix the errors and allow for advanced optimization again.